### PR TITLE
Rename PonyASIO to PonyAsio

### DIFF
--- a/lori/pony_asio.pony
+++ b/lori/pony_asio.pony
@@ -6,7 +6,7 @@ use @pony_asio_event_set_readable[None](event: AsioEventID, readable: Bool)
 use @pony_asio_event_set_writeable[None](event: AsioEventID, writeable: Bool)
 use @pony_asio_event_unsubscribe[None](event: AsioEventID)
 
-primitive PonyASIO
+primitive PonyAsio
   fun create_event(the_actor: AsioEventNotify, fd: U32): AsioEventID =>
     @pony_asio_event_create(the_actor, fd, AsioEvent.read_write(), 0, true)
 

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -34,7 +34,7 @@ class TCPConnection
     fd = fd'
     // TODO: sort out client and server side setup. it's a mess
     _enclosing = enclosing
-    _event = PonyASIO.create_event(enclosing, fd)
+    _event = PonyAsio.create_event(enclosing, fd)
     open()
     // should set readable state
     enclosing.on_connected()
@@ -64,7 +64,7 @@ class TCPConnection
       _state = BitSet.unset(_state, 0)
       unwriteable()
       PonyTCP.shutdown(fd)
-      PonyASIO.unsubscribe(_event)
+      PonyAsio.unsubscribe(_event)
       fd = -1
     end
 
@@ -145,7 +145,7 @@ class TCPConnection
           buffer.cpointer(),
           buffer.size())?
           if (bytes_read == 0) then
-            PonyASIO.set_unreadable(_event)
+            PonyAsio.set_unreadable(_event)
             // would block. try again later
             // TCPConnection handles with:
             //@pony_asio_event_set_readable[None](self().event, false)
@@ -199,7 +199,7 @@ class TCPConnection
     // throttled means we are also unwriteable
     // being unthrottled doesn't however mean we are writable
     unwriteable()
-    PonyASIO.set_unwriteable(_event)
+    PonyAsio.set_unwriteable(_event)
 
   fun ref unthrottled() =>
     _state = BitSet.unset(_state, 2)
@@ -217,7 +217,7 @@ class TCPConnection
         if AsioEvent.writeable(flags) then
           // TODO: this assumes the connection succeed. That might not be true.
           // more logic needs to go here
-          fd = PonyASIO.event_fd(event)
+          fd = PonyAsio.event_fd(event)
           _event = event
           open()
           s.on_connected()
@@ -237,7 +237,7 @@ class TCPConnection
         end
 
         if AsioEvent.disposable(flags) then
-          PonyASIO.destroy(event)
+          PonyAsio.destroy(event)
           _event = AsioEvent.none()
         end
       end

--- a/lori/tcp_listener.pony
+++ b/lori/tcp_listener.pony
@@ -14,7 +14,7 @@ class TCPListener
     _enclosing = enclosing
     let event = PonyTCP.listen(enclosing, host, port)
     if not event.is_null() then
-      _fd = PonyASIO.event_fd(event)
+      _fd = PonyAsio.event_fd(event)
       _event = event
       state = Open
       enclosing.on_listening()
@@ -35,7 +35,7 @@ class TCPListener
         state = Closed
 
         if not _event.is_null() then
-          PonyASIO.unsubscribe(_event)
+          PonyAsio.unsubscribe(_event)
           PonyTCP.close(_fd)
           _fd = -1
           e.on_closed()
@@ -56,7 +56,7 @@ class TCPListener
     end
 
     if AsioEvent.disposable(flags) then
-      PonyASIO.destroy(_event)
+      PonyAsio.destroy(_event)
       _event = AsioEvent.none()
       state = Closed
     end


### PR DESCRIPTION
Asio is used in the Pony standard library even if I think it should be ASIO.
This change is for consistency with the standard library.