### PR TITLE
Allow Lori to work without using ASIO OneShot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,13 @@ version: 2
 jobs:
   release-vs-ponyc-release:
     docker:
-      - image: ponylang/ponyc:release
+      - image: ponylang/ponyc:latest
     steps:
       - checkout
       - run: make test config=release
   debug-vs-ponyc-release:
     docker:
-      - image: ponylang/ponyc:release
+      - image: ponylang/ponyc:latest
     steps:
       - checkout
       - run: make test config=debug

--- a/lori/pony_tcp.pony
+++ b/lori/pony_tcp.pony
@@ -2,7 +2,8 @@ use @pony_os_accept[U32](event: AsioEventID)
 use @pony_os_connect_tcp[U32](the_actor: AsioEventNotify,
   host: Pointer[U8] tag,
   port: Pointer[U8] tag,
-  from: Pointer[U8] tag)
+  from: Pointer[U8] tag,
+  asio_flags: U32)
 use @pony_os_listen_tcp[AsioEventID](the_actor: AsioEventNotify,
   host: Pointer[U8] tag,
   port: Pointer[U8] tag)
@@ -32,13 +33,15 @@ primitive PonyTCP
   fun connect(the_actor: AsioEventNotify,
     host: String,
     port: String,
-    from: String)
+    from: String,
+    asio_flags: U32)
     : U32
   =>
     @pony_os_connect_tcp(the_actor,
       host.cstring(),
       port.cstring(),
-      from.cstring())
+      from.cstring(),
+      asio_flags)
 
   fun receive(event: AsioEventID,
     buffer: Pointer[U8] tag,

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -30,7 +30,7 @@ class TCPConnection
   =>
     // TODO: handle happy eyeballs here - connect count
     _enclosing = enclosing
-    PonyTCP.connect(enclosing, host, port, from)
+    PonyTCP.connect(enclosing, host, port, from, AsioEvent.read_write())
 
   new server(auth: IncomingTCPAuth,
     fd': U32,


### PR DESCRIPTION
Pony 0.28.1 fixed a bug where Epoll OneShot events were being done using
edge triggering. That fix, PR#3136
https://github.com/ponylang/ponyc/pull/3136, then proceeded to break
Lori.

The problem? The Pony TCP runtime that Lori currently uses was creating
a one shot event for connections. Lori doesn't currently support one
shot at all.

A recent commit to Pony master
https://github.com/ponylang/ponyc/commit/5f29b1b7edc59d3f1edf797fa86ebf0d4874695f
fixes the issue and allows Lori to work again. This commit brings Lori
up to date with those changes so Lori can work without one shot being
implemented.