### PR TITLE
Add MacOS CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,23 @@
+task:
+  osx_instance:
+    image: high-sierra-xcode-9.4.1
+
+  name: "release-vs-ponyc-release-macOS"
+
+  install_script:
+    - brew install ponyc
+
+  test_script:
+    - make test config=debug
+
+task:
+  osx_instance:
+    image: high-sierra-xcode-9.4.1
+
+  name: "debug-vs-ponyc-release-macOS"
+
+  install_script:
+    - brew install ponyc
+
+  test_script:
+    - make test config=debug


### PR DESCRIPTION
Runs for every PR. Installs latest release via Homebrew.

Will run debug and release version of Lori code against the release
version of Pony. (There's no debug version of Ponyc released at this
time).

Closes #41