### PR TITLE
Remove unneeded TCP read buffer resizing

### DIFF
--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -174,7 +174,6 @@ class TCPConnection
             end
 
             if total_bytes_read >= _max_read_buffer_size then
-              _resize_read_buffer()
               s._read_again()
               return
             end


### PR DESCRIPTION
It served no real purpose. Would likely end up doing extra allocations
and extra system calls that might not be needed.