### PR TITLE
Switch CI back to being against release Ponyc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,13 @@ version: 2
 jobs:
   release-vs-ponyc-release:
     docker:
-      - image: ponylang/ponyc:latest
+      - image: ponylang/ponyc:release
     steps:
       - checkout
       - run: make test config=release
   debug-vs-ponyc-release:
     docker:
-      - image: ponylang/ponyc:latest
+      - image: ponylang/ponyc:release
     steps:
       - checkout
       - run: make test config=debug


### PR DESCRIPTION
Now that lori can build against it again. There was a "bug" in Pony 0.28.x that prevented lori from building.

Closes #37